### PR TITLE
fix update billing info : delete old payment mean before add new one

### DIFF
--- a/django_recurly/models.py
+++ b/django_recurly/models.py
@@ -381,23 +381,6 @@ class Account(SaveDirtyModel, TimeStampedModel):
 
         return account, subscription
 
-    def update_billing_info(self, billing_info, account_url):
-        """Change this account's billing information to the given `BillingInfo`."""
-        url = urljoin(account_url, '%s/billing_info' % self.account_code)
-        response = billing_info.http_request(url, 'PUT', billing_info,
-            {'Content-Type': 'application/xml; charset=utf-8'})
-        if response.status == 200:
-            pass
-        elif response.status == 201:
-            billing_info._url = response.getheader('Location')
-        else:
-            billing_info.raise_http_error(response)
-
-        response_xml = response.read()
-        logging.getLogger('recurly.http.response').debug(response_xml)
-        self.billing_info.clear_payment_mean()
-        billing_info.update_from_element(ElementTree.fromstring(response_xml))
-
 
 class BillingInfo(SaveDirtyModel):
 
@@ -491,7 +474,7 @@ class BillingInfo(SaveDirtyModel):
 
         self.save(remote=False)
 
-    def clear_payment_mean(self):
+    def purge_payment_mean(self):
         self.card_type = None
         self.month = None
         self.year = None

--- a/django_recurly/models.py
+++ b/django_recurly/models.py
@@ -15,8 +15,6 @@ from django_recurly.utils import recurly
 from django_recurly import handlers
 from django.db.models.signals import post_save
 import importlib
-from urllib.parse import urljoin
-from xml.etree import ElementTree
 
 import logging, sys
 logger = logging.getLogger(__name__)
@@ -474,12 +472,24 @@ class BillingInfo(SaveDirtyModel):
 
         self.save(remote=False)
 
-    def purge_payment_mean(self):
+    def purge_billing_info(self):
+        self.company = None
+        self.address1 = None
+        self.address2 = None
+        self.city = None
+        self.state = None
+        self.zip = None
+        self.country = None
+        self.phone = None
+        self.vat_number = None
+        self.ip_address = None
+        self.ip_address_country = None
         self.card_type = None
         self.month = None
         self.year = None
         self.last_four = None
         self.paypal_billing_agreement_id = None
+        self.updated_at = None
         self.save()
 
 

--- a/django_recurly/provisioning.py
+++ b/django_recurly/provisioning.py
@@ -63,7 +63,7 @@ def update_and_sync_recurly_billing_info(account, billing_info_params):
     recurly_account = account.get_recurly_account()
     billing_info = recurly.BillingInfo(**billing_info_params)
     recurly_account.update_billing_info(billing_info)
-    account.billing_info.purge_payment_mean()
+    account.billing_info.purge_billing_info()
     recurly_account = account.get_recurly_account()  # refresh
     local_account = update_local_account_data_from_recurly_resource(recurly_account=recurly_account)
     return local_account

--- a/django_recurly/provisioning.py
+++ b/django_recurly/provisioning.py
@@ -62,7 +62,7 @@ def update_and_sync_recurly_billing_info(account, billing_info_params):
     """
     recurly_account = account.get_recurly_account()
     billing_info = recurly.BillingInfo(**billing_info_params)
-    recurly_account.update_billing_info(billing_info)
+    account.update_billing_info(billing_info, recurly_account._url)
     recurly_account = account.get_recurly_account()  # refresh
     local_account = update_local_account_data_from_recurly_resource(recurly_account=recurly_account)
     return local_account

--- a/django_recurly/provisioning.py
+++ b/django_recurly/provisioning.py
@@ -62,7 +62,8 @@ def update_and_sync_recurly_billing_info(account, billing_info_params):
     """
     recurly_account = account.get_recurly_account()
     billing_info = recurly.BillingInfo(**billing_info_params)
-    account.update_billing_info(billing_info, recurly_account._url)
+    recurly_account.update_billing_info(billing_info, recurly_account._url)
+    account.billing_info.purge_payment_mean()
     recurly_account = account.get_recurly_account()  # refresh
     local_account = update_local_account_data_from_recurly_resource(recurly_account=recurly_account)
     return local_account

--- a/django_recurly/provisioning.py
+++ b/django_recurly/provisioning.py
@@ -62,7 +62,7 @@ def update_and_sync_recurly_billing_info(account, billing_info_params):
     """
     recurly_account = account.get_recurly_account()
     billing_info = recurly.BillingInfo(**billing_info_params)
-    recurly_account.update_billing_info(billing_info, recurly_account._url)
+    recurly_account.update_billing_info(billing_info)
     account.billing_info.purge_payment_mean()
     recurly_account = account.get_recurly_account()  # refresh
     local_account = update_local_account_data_from_recurly_resource(recurly_account=recurly_account)


### PR DESCRIPTION
Ticket lié : https://medici.atlassian.net/browse/B2C-1048

Override une méthode de la lib recurly pour supprimer les moyens de paiement existant avant de mettre à jour la base de données.